### PR TITLE
CI/CD automation 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,9 @@ jobs:
   build:
     runs-on: windows-latest
     
+    permissions:
+      contents: read
+    
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,42 @@
+name: Build Andromeda
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: windows-latest
+    
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      
+    - name: Setup MSBuild
+      uses: microsoft/setup-msbuild@v2
+      
+    - name: Setup VSWhere
+      uses: warrenbuckley/Setup-VSWhere@v1
+      
+    - name: Restore NuGet packages
+      run: nuget restore Andromeda-Dota2-Base.sln
+      
+    - name: Build Solution
+      run: msbuild Andromeda-Dota2-Base.sln /p:Configuration=Release /p:Platform=x64 /m /verbosity:minimal
+      
+    - name: Upload Andromeda-Dota2-Base DLL
+      uses: actions/upload-artifact@v4
+      with:
+        name: Andromeda-Dota2-Base-DLL
+        path: x64/Release/Andromeda-Dota2-Base.dll
+        if-no-files-found: warn
+        
+    - name: Upload Andromeda-Injector Executable
+      uses: actions/upload-artifact@v4
+      with:
+        name: Andromeda-Dota2-Injector
+        path: x64/Release/Andromeda-Dota2.exe
+        if-no-files-found: warn

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,12 +18,6 @@ jobs:
     - name: Setup MSBuild
       uses: microsoft/setup-msbuild@v2
       
-    - name: Setup VSWhere
-      uses: warrenbuckley/Setup-VSWhere@v1
-      
-    - name: Restore NuGet packages
-      run: nuget restore Andromeda-Dota2-Base.sln
-      
     - name: Build Solution
       run: msbuild Andromeda-Dota2-Base.sln /p:Configuration=Release /p:Platform=x64 /m /verbosity:minimal
       


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the build process for the Andromeda project. The workflow is triggered on pushes, pull requests, and manual dispatches for the main and master branches, and it sets up a Windows build environment to compile the solution and upload the resulting artifacts.

CI/CD automation:

* Added a new workflow file `.github/workflows/build.yml` that sets up continuous integration for building the Andromeda project on Windows using GitHub Actions.
* Configured the workflow to build the `Andromeda-Dota2-Base.sln` solution in Release/x64 mode and upload both the DLL and executable as build artifacts.